### PR TITLE
Add missing error handling in thumbnail creation

### DIFF
--- a/classes/FileUtils.php
+++ b/classes/FileUtils.php
@@ -82,7 +82,8 @@ class WPFB_FileUtils {
 
 		$tmp_del && is_file($tmp_img) && unlink($tmp_img);
 
-		if (!$thumb)
+		// if the thumb is still missing, cancel thumbnail creation
+		if (!$thumb || is_wp_error( $thumb ))
 			return false;
 
 		$fn = $dir . str_ireplace(array('.pdf_thumb', '.jpg_thumb', '.tiff_thumb', '.tif_thumb', '.bmp_thumb'), '', $thumb['file']);


### PR DESCRIPTION
My sync was broken because of a thumbnail creation error not handled in CreateThumbnail.

I added a check on this case to drop thumbnail creation and continue syncing.