### PR TITLE
added check for WP-CLI to fix an undefined index HTTP_HOST notice

### DIFF
--- a/classes/Core.php
+++ b/classes/Core.php
@@ -221,7 +221,13 @@ class WPFB_Core {
 			elseif (!empty($_GET['wpfb_cat']))
 				self::$file_browser_item = WPFB_Category::GetCat($_GET['wpfb_cat']);
 			else {
-				$url = (is_ssl() ? 'https' : 'http') . '://' . $_SERVER["HTTP_HOST"] . stripslashes($_SERVER['REQUEST_URI']);
+				$url = '';
+
+				if ( ! defined( 'WP_CLI' ) || defined( 'WP_CLI' ) && ! WP_CLI ) {
+					// don't access the $_SERVER parameter if it's running while a WP-CLI command is being used
+					$url = (is_ssl() ? 'https' : 'http') . '://' . $_SERVER["HTTP_HOST"] . stripslashes($_SERVER['REQUEST_URI']);
+				}
+
 				if (($qs = strpos($url, '?')) !== false)
 					$url = substr($url, 0, $qs); // remove query string	
 				$path = trim(substr($url, strlen(WPFB_Core::GetPostUrl($id))), '/');


### PR DESCRIPTION
With the plugin active, running WP-CLI commands was causing an undefined index notice.

```
PHP Notice:  Undefined index: HTTP_HOST in /srv/www/wordpress-default/htdocs/wp-content/plugins/WP-Filebase/classes/Core.php on line 224
Notice: Undefined index: HTTP_HOST in /srv/www/wordpress-default/htdocs/wp-content/plugins/WP-Filebase/classes/Core.php on line 224
Revision ID 20408 has been deleted.
PHP Notice:  Undefined index: HTTP_HOST in /srv/www/wordpress-default/htdocs/wp-content/plugins/WP-Filebase/classes/Core.php on line 224
Notice: Undefined index: HTTP_HOST in /srv/www/wordpress-default/htdocs/wp-content/plugins/WP-Filebase/classes/Core.php on line 224
Revision ID 20424 has been deleted.
PHP Notice:  Undefined index: HTTP_HOST in /srv/www/wordpress-default/htdocs/wp-content/plugins/WP-Filebase/classes/Core.php on line 224
Notice: Undefined index: HTTP_HOST in /srv/www/wordpress-default/htdocs/wp-content/plugins/WP-Filebase/classes/Core.php on line 224
```

This PR should resolve that notice.
