### PR TITLE
Fixed stripslashes_deep() call so that it doesn't strip the slashes from the $_FILES array, which will mangle paths on windows filesystems.

### DIFF
--- a/classes/Admin.php
+++ b/classes/Admin.php
@@ -884,7 +884,7 @@ class WPFB_Admin {
 		// if category is set in widget options, force to use this. security done with nonce checking ($_POST['cat'] is reliable)
 		if ($_POST['cat'] >= 0)
 			$_POST['file_category'] = $_POST['cat'];
-		$result = WPFB_Admin::InsertFile(stripslashes_deep(array_merge($_POST, $_FILES, array('frontend_upload' => true, 'form' => empty($form) ? null : $form))));
+		$result = WPFB_Admin::InsertFile(array_merge($_FILES, stripslashes_deep(array_merge($_POST, array('frontend_upload' => true, 'form' => empty($form) ? null : $form)))));
 		if (isset($result['error']) && $result['error']) {
 			$content .= '<div id="message" class="updated fade"><p>' . $result['error'] . '</p></div>';
 			$title .= __('Error');

--- a/classes/AdminGuiFiles.php
+++ b/classes/AdminGuiFiles.php
@@ -79,7 +79,7 @@ static function Display()
 				$_POST['file_date'] =  sprintf( "%04d-%02d-%02d %02d:%02d:%02d", $aa, $mm, $jj, $hh, $mn, $ss );
 			}
 			
-			$result = WPFB_Admin::InsertFile(stripslashes_deep(array_merge($_POST, $_FILES)), true);
+			$result = WPFB_Admin::InsertFile(array_merge(stripslashes_deep($_POST), $_FILES), true);
 			if(isset($result['error']) && $result['error']) {
 				$message = $result['error'] . '<br /><a href="javascript:history.back()">' . __("Go back") . '</a>';
 			} else {

--- a/screens/editor-plugin.php
+++ b/screens/editor-plugin.php
@@ -268,7 +268,7 @@ if($action =='addfile' || $action =='updatefile')
 	if(!wp_verify_nonce($_POST['wpfb-file-nonce'], $nonce_action."-editor") && !wp_verify_nonce($_POST['wpfb-file-nonce'], $nonce_action) )
 		wp_die(__('Cheatin&#8217; uh?'));
 	
-	$result = WPFB_Admin::InsertFile(stripslashes_deep(array_merge($_POST, $_FILES)));
+	$result = WPFB_Admin::InsertFile(array_merge(stripslashes_deep($_POST), $_FILES));
 	if(isset($result['error']) && $result['error']) {
 		?><div id="message" class="updated fade"><p><?php echo $result['error']; ?></p></div><?php
 		$file = new WPFB_File($_POST);


### PR DESCRIPTION
On windows server's the `$_FILES` array contains the path to the file, with slashes '\', these slashes get removed by the `stripslashes_deep()` call, which makes the path to the file meaningless, and results in the plugin being unable to upload the file.